### PR TITLE
Restore widget theme and intents on update

### DIFF
--- a/app/src/main/java/org/asdtm/goodweather/widget/LessWidgetProvider.java
+++ b/app/src/main/java/org/asdtm/goodweather/widget/LessWidgetProvider.java
@@ -74,17 +74,8 @@ public class LessWidgetProvider extends AppWidgetProvider {
                                                       R.layout.widget_less_3x1);
 
             setWidgetTheme(context, remoteViews);
+            setWidgetIntents(context, remoteViews);
             preLoadWeather(context, remoteViews);
-
-            Intent intent = new Intent(context, LessWidgetProvider.class);
-            intent.setAction(Constants.ACTION_FORCED_APPWIDGET_UPDATE);
-            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
-            remoteViews.setOnClickPendingIntent(R.id.widget_button_refresh, pendingIntent);
-
-            Intent intentStartActivity = new Intent(context, MainActivity.class);
-            PendingIntent pendingIntent2 = PendingIntent.getActivity(context, 0,
-                                                                     intentStartActivity, 0);
-            remoteViews.setOnClickPendingIntent(R.id.widget_root, pendingIntent2);
 
             appWidgetManager.updateAppWidget(appWidgetId, remoteViews);
         }
@@ -123,15 +114,28 @@ public class LessWidgetProvider extends AppWidgetProvider {
         remoteViews.setTextViewText(R.id.widget_last_update, lastUpdate);
     }
 
-    private void setWidgetTheme(Context context, RemoteViews remoteViews) {
+    public static void setWidgetTheme(Context context, RemoteViews remoteViews) {
 
         int textColorId = AppPreference.getTextColor(context);
         int backgroundColorId = AppPreference.getBackgroundColor(context);
         int windowHeaderBackgroundColorId = AppPreference.getWindowHeaderBackgroundColorId(context);
-        
+
         remoteViews.setInt(R.id.widget_root, "setBackgroundColor", backgroundColorId);
         remoteViews.setTextColor(R.id.widget_temperature, textColorId);
         remoteViews.setTextColor(R.id.widget_description, textColorId);
         remoteViews.setInt(R.id.header_layout, "setBackgroundColor", windowHeaderBackgroundColorId);
+    }
+
+    public static void setWidgetIntents(Context context, RemoteViews remoteViews) {
+
+        Intent intent = new Intent(context, LessWidgetProvider.class);
+        intent.setAction(Constants.ACTION_FORCED_APPWIDGET_UPDATE);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
+        remoteViews.setOnClickPendingIntent(R.id.widget_button_refresh, pendingIntent);
+
+        Intent intentStartActivity = new Intent(context, MainActivity.class);
+        PendingIntent pendingIntent2 = PendingIntent.getActivity(context, 0,
+                                                                  intentStartActivity, 0);
+        remoteViews.setOnClickPendingIntent(R.id.widget_root, pendingIntent2);
     }
 }

--- a/app/src/main/java/org/asdtm/goodweather/widget/LessWidgetService.java
+++ b/app/src/main/java/org/asdtm/goodweather/widget/LessWidgetService.java
@@ -65,6 +65,9 @@ public class LessWidgetService extends IntentService {
             RemoteViews remoteViews = new RemoteViews(this.getPackageName(),
                                                       R.layout.widget_less_3x1);
 
+            LessWidgetProvider.setWidgetTheme(this, remoteViews);
+            LessWidgetProvider.setWidgetIntents(this, remoteViews);
+
             String iconId = weather.currentWeather.getIdIcon();
             String weatherIcon = Utils.getStrIcon(this, iconId);
             String lastUpdate = Utils.setLastUpdateTime(this, AppPreference

--- a/app/src/main/java/org/asdtm/goodweather/widget/MoreWidgetProvider.java
+++ b/app/src/main/java/org/asdtm/goodweather/widget/MoreWidgetProvider.java
@@ -73,18 +73,8 @@ public class MoreWidgetProvider extends AppWidgetProvider {
                                                       R.layout.widget_more_3x3);
 
             setWidgetTheme(context, remoteViews);
+            setWidgetIntents(context, remoteViews);
             preLoadWeather(context, remoteViews);
-
-            Intent intentRefreshService = new Intent(context, MoreWidgetProvider.class);
-            intentRefreshService.setAction(Constants.ACTION_FORCED_APPWIDGET_UPDATE);
-            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0,
-                                                                     intentRefreshService, 0);
-            remoteViews.setOnClickPendingIntent(R.id.widget_button_refresh, pendingIntent);
-
-            Intent intentStartActivity = new Intent(context, MainActivity.class);
-            PendingIntent pendingIntent2 = PendingIntent.getActivity(context, 0,
-                                                                     intentStartActivity, 0);
-            remoteViews.setOnClickPendingIntent(R.id.widget_root, pendingIntent2);
 
             appWidgetManager.updateAppWidget(appWidgetId, remoteViews);
         }
@@ -152,7 +142,7 @@ public class MoreWidgetProvider extends AppWidgetProvider {
         remoteViews.setTextViewText(R.id.widget_last_update, lastUpdate);
     }
 
-    private void setWidgetTheme(Context context, RemoteViews remoteViews) {
+    public static void setWidgetTheme(Context context, RemoteViews remoteViews) {
         int textColorId = AppPreference.getTextColor(context);
         int backgroundColorId = AppPreference.getBackgroundColor(context);
         int windowHeaderBackgroundColorId = AppPreference.getWindowHeaderBackgroundColorId(context);
@@ -166,5 +156,19 @@ public class MoreWidgetProvider extends AppWidgetProvider {
         remoteViews.setTextColor(R.id.widget_pressure, textColorId);
         remoteViews.setTextColor(R.id.widget_clouds, textColorId);
         remoteViews.setInt(R.id.header_layout, "setBackgroundColor", windowHeaderBackgroundColorId);
+    }
+
+    public static void setWidgetIntents(Context context, RemoteViews remoteViews) {
+
+        Intent intentRefreshService = new Intent(context, MoreWidgetProvider.class);
+        intentRefreshService.setAction(Constants.ACTION_FORCED_APPWIDGET_UPDATE);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0,
+                                                                  intentRefreshService, 0);
+        remoteViews.setOnClickPendingIntent(R.id.widget_button_refresh, pendingIntent);
+
+        Intent intentStartActivity = new Intent(context, MainActivity.class);
+        PendingIntent pendingIntent2 = PendingIntent.getActivity(context, 0,
+                                                                  intentStartActivity, 0);
+        remoteViews.setOnClickPendingIntent(R.id.widget_root, pendingIntent2);
     }
 }

--- a/app/src/main/java/org/asdtm/goodweather/widget/MoreWidgetService.java
+++ b/app/src/main/java/org/asdtm/goodweather/widget/MoreWidgetService.java
@@ -94,6 +94,10 @@ public class MoreWidgetService extends IntentService {
 
             RemoteViews remoteViews = new RemoteViews(this.getPackageName(),
                                                       R.layout.widget_more_3x3);
+
+            MoreWidgetProvider.setWidgetTheme(this, remoteViews);
+            MoreWidgetProvider.setWidgetIntents(this, remoteViews);
+
             remoteViews.setTextViewText(R.id.widget_city, Utils.getCityAndCountry(this));
             remoteViews.setTextViewText(R.id.widget_temperature, temperature + temperatureScale);
             if(!AppPreference.hideDescription(this))


### PR DESCRIPTION
For me this change resolves issue #31. It essentially makes sure to set the widget theme and create its intents also whenever the More/LessWidgetService runs onHandleIntent(). This might not be the best possible solution, but it appears to have the desired effect. And so far it does not show bad side-effects.